### PR TITLE
Add detailed README on data science workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,40 @@
 # data_scientist
-Predictions. Time series
+
+Este repositório demonstra um fluxo completo de boas práticas de ciência de dados. Abaixo estão descritos os passos chave e sugestões de extensões para cada etapa.
+
+## 1. EDA (Análise Exploratória de Dados)
+1. **Compreensão do domínio**: entenda o contexto do problema e as fontes de dados.
+2. **Carregamento e inspeção inicial**: verifique formatos, tipos e estatísticas descritivas.
+3. **Visualizações**: distribuições (histogramas, boxplots) e relações (scatterplots, heatmaps de correlação).
+4. **Heurísticas com distribuições de probabilidade**: identifique padrões, outliers e comportamento anômalo usando distribuições teóricas (Normal, Exponencial etc.).
+5. **Limpeza e tratamento de valores ausentes**: elimine ou impute seguindo a lógica do negócio.
+
+## 2. Benchmark e Escolha de Modelo
+1. **Definição de métricas**: escolha métricas alinhadas ao objetivo (ex.: MSE, ROC AUC, etc.).
+2. **Benchmarks rápidos**: comece com modelos simples (baseline) e utilize validação cruzada para comparar opções.
+3. **Seleção guiada por heurísticas**: avalie se distribuições de probabilidade ou características temporais indicam modelos específicos (p. ex. modelos de série temporal ou regressão regularizada).
+
+## 3. Pipeline de Features e Feature Store
+1. **Engenharia de features**: transforme variáveis brutas em atributos mais informativos (normalização, codificações categóricas, agregações temporais, etc.).
+2. **Seleção automática**: utilize técnicas como filtro, wrapper ou embedded (ex.: L1 regularização) para reduzir dimensionalidade.
+3. **Feature Store**: armazene features reutilizáveis em um repositório central para manter consistência entre experimentos e produção.
+
+## 4. Integração com MLflow
+1. **Rastreamento de experiências**: registre runs no MLflow para salvar hiperparâmetros, métricas e artefatos.
+2. **Visualização de métricas**: compare modelos, acesse curvas e histórico de execuções.
+3. **Revisão de correlações**: reavalie features após cada experimento e, se necessário, teste outro modelo mais adequado.
+
+## 5. CI/CD e Deploy Canário
+1. **Pipeline automático**: configure integração contínua para rodar testes e validações de dados sempre que há novas mudanças.
+2. **Deploy canário**: envie o modelo para um subconjunto reduzido de usuários ou dados e monitore métricas em tempo real.
+3. **Exemplo de falha**: se o canário apresentar piora de performance, o CI/CD realiza rollback automático ou inicia nova execução para corrigir parâmetros.
+4. **Deploy final**: após a correção automática, o pipeline promove o modelo aprimorado para produção completa.
+
+## 6. Próximos Passos e Extensões
+- Monitoramento contínuo de dados para detectar drift.
+- Expansão da feature store e documentação de metadados.
+- Integração com ferramentas de orquestração (ex.: Airflow ou Prefect).
+- Criação de testes unitários e de integração dedicados aos pipelines de dados.
+
+Este guia resume como montar um fluxo completo, desde EDA até deploy, mantendo boas práticas de ciência de dados e automações de CI/CD para garantir modelos confiáveis e fáceis de manter.
+


### PR DESCRIPTION
## Summary
- replace minimal README with detailed data-science workflow guide
- document EDA heuristics, benchmarking, feature pipeline, MLflow and CI/CD with canary deploy

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6855a9a6efb0832391264da36df39bf9