### PR TITLE
Add modular workflow with orchestrator

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,53 @@
 # data_scientist
-Predictions. Time series
+
+Este repositório demonstra um fluxo completo de boas práticas de ciência de dados. Abaixo estão descritos os passos chave e sugestões de extensões para cada etapa.
+
+## 1. EDA (Análise Exploratória de Dados)
+1. **Compreensão do domínio**: entenda o contexto do problema e as fontes de dados.
+2. **Carregamento e inspeção inicial**: verifique formatos, tipos e estatísticas descritivas.
+3. **Visualizações**: distribuições (histogramas, boxplots) e relações (scatterplots, heatmaps de correlação).
+4. **Heurísticas com distribuições de probabilidade**: identifique padrões, outliers e comportamento anômalo usando distribuições teóricas (Normal, Exponencial etc.).
+5. **Limpeza e tratamento de valores ausentes**: elimine ou impute seguindo a lógica do negócio.
+
+## 2. Benchmark e Escolha de Modelo
+1. **Definição de métricas**: escolha métricas alinhadas ao objetivo (ex.: MSE, ROC AUC, etc.).
+2. **Benchmarks rápidos**: comece com modelos simples (baseline) e utilize validação cruzada para comparar opções.
+3. **Seleção guiada por heurísticas**: avalie se distribuições de probabilidade ou características temporais indicam modelos específicos (p. ex. modelos de série temporal ou regressão regularizada).
+
+## 3. Pipeline de Features e Feature Store
+1. **Engenharia de features**: transforme variáveis brutas em atributos mais informativos (normalização, codificações categóricas, agregações temporais, etc.).
+2. **Seleção automática**: utilize técnicas como filtro, wrapper ou embedded (ex.: L1 regularização) para reduzir dimensionalidade.
+3. **Feature Store**: armazene features reutilizáveis em um repositório central para manter consistência entre experimentos e produção.
+
+## 4. Integração com MLflow
+1. **Rastreamento de experiências**: registre runs no MLflow para salvar hiperparâmetros, métricas e artefatos.
+2. **Visualização de métricas**: compare modelos, acesse curvas e histórico de execuções.
+3. **Revisão de correlações**: reavalie features após cada experimento e, se necessário, teste outro modelo mais adequado.
+
+## 5. CI/CD e Deploy Canário
+1. **Pipeline automático**: configure integração contínua para rodar testes e validações de dados sempre que há novas mudanças.
+2. **Deploy canário**: envie o modelo para um subconjunto reduzido de usuários ou dados e monitore métricas em tempo real.
+3. **Exemplo de falha**: se o canário apresentar piora de performance, o CI/CD realiza rollback automático ou inicia nova execução para corrigir parâmetros.
+4. **Deploy final**: após a correção automática, o pipeline promove o modelo aprimorado para produção completa.
+
+## 6. Próximos Passos e Extensões
+- Monitoramento contínuo de dados para detectar drift.
+- Expansão da feature store e documentação de metadados.
+- Integração com ferramentas de orquestração (ex.: Airflow ou Prefect).
+- Criação de testes unitários e de integração dedicados aos pipelines de dados.
+
+Este guia resume como montar um fluxo completo, desde EDA até deploy, mantendo boas práticas de ciência de dados e automações de CI/CD para garantir modelos confiáveis e fáceis de manter.
+
+### Estrutura de Código
+
+O diretório `src/ds_workflow` contém módulos pequenos que exemplificam cada etapa do fluxo:
+
+- `eda.py` – carregamento do dataset de demonstração e inspeções básicas;
+- `modeling.py` – funções de benchmark de modelos;
+- `feature_store.py` – criação do pipeline de features e armazenamento em CSV;
+- `mlflow_utils.py` – registro simplificado de runs no MLflow;
+- `deploy.py` – simulação de um deploy canário com rollback;
+- `main.py` – orquestrador que executa todas as etapas em sequência.
+
+Executar `python -m src.ds_workflow.main` reproduz o fluxo completo.
+

--- a/src/ds_workflow/deploy.py
+++ b/src/ds_workflow/deploy.py
@@ -1,0 +1,8 @@
+
+def simulate_canary(old_metric: float, new_metric: float, threshold: float = 0.02):
+    """Avalia métrica do deploy canário e retorna métrica atualizada e status."""
+    if new_metric + threshold < old_metric:
+        print("Canário falhou, iniciando rollback...")
+        return old_metric, False
+    print("Novo modelo aprovado!")
+    return new_metric, True

--- a/src/ds_workflow/eda.py
+++ b/src/ds_workflow/eda.py
@@ -1,0 +1,28 @@
+import pandas as pd
+import seaborn as sns
+import matplotlib.pyplot as plt
+from scipy import stats
+
+
+def load_wine_dataset():
+    """Carrega o dataset Wine do scikit-learn como DataFrame."""
+    from sklearn.datasets import load_wine
+    data = load_wine()
+    df = pd.DataFrame(data.data, columns=data.feature_names)
+    df['target'] = data.target
+    return df
+
+
+def run_basic_eda(df):
+    """Executa inspeções e visualizações básicas."""
+    stats_desc = df.describe()
+    corr = df.corr()
+    sns.heatmap(corr, cmap="coolwarm")
+    plt.close()  # evita abrir janelas interativas
+    return stats_desc, corr
+
+
+def check_normality(series):
+    """Retorna o p-valor do teste de normalidade de D'Agostino."""
+    _, p = stats.normaltest(series)
+    return p

--- a/src/ds_workflow/feature_store.py
+++ b/src/ds_workflow/feature_store.py
@@ -1,0 +1,16 @@
+import pandas as pd
+from sklearn.pipeline import Pipeline
+from sklearn.preprocessing import StandardScaler
+from sklearn.feature_selection import SelectKBest, f_classif
+
+
+def build_feature_pipeline(k=8):
+    """Cria pipeline de transformação e seleção de features."""
+    return Pipeline([
+        ("scale", StandardScaler()),
+        ("select", SelectKBest(score_func=f_classif, k=k)),
+    ])
+
+
+def save_features(X_transformed, path="feature_store.csv"):
+    pd.DataFrame(X_transformed).to_csv(path, index=False)

--- a/src/ds_workflow/main.py
+++ b/src/ds_workflow/main.py
@@ -1,0 +1,33 @@
+from . import eda, modeling, feature_store, mlflow_utils, deploy
+
+
+def run_workflow():
+    df = eda.load_wine_dataset()
+    eda.run_basic_eda(df)
+    p_value = eda.check_normality(df["alcohol"])
+    print("p-value normalidade:", p_value)
+
+    X = df.drop("target", axis=1)
+    y = df["target"]
+    scores = modeling.benchmark_models(X, y)
+    print("Benchmark:", scores)
+
+    pipeline = feature_store.build_feature_pipeline()
+    X_feat = pipeline.fit_transform(X, y)
+    feature_store.save_features(X_feat)
+
+    # Usa modelo mais simples para log no MLflow
+    from sklearn.linear_model import LogisticRegression
+    acc = mlflow_utils.log_run(LogisticRegression(max_iter=1000), X_feat, y)
+    print("Acurácia registrada:", acc)
+
+    current = scores["logistic_regression"]
+    candidate = current - 0.05
+    current, ok = deploy.simulate_canary(current, candidate)
+    if not ok:
+        candidate = current + 0.03
+        current, _ = deploy.simulate_canary(current, candidate)
+
+
+if __name__ == "__main__":
+    run_workflow()

--- a/src/ds_workflow/mlflow_utils.py
+++ b/src/ds_workflow/mlflow_utils.py
@@ -1,0 +1,11 @@
+import mlflow
+
+
+def log_run(model, X, y, experiment="wine_demo"):
+    mlflow.set_experiment(experiment)
+    with mlflow.start_run():
+        model.fit(X, y)
+        acc = model.score(X, y)
+        mlflow.log_metric("accuracy", acc)
+        mlflow.sklearn.log_model(model, "model")
+    return acc

--- a/src/ds_workflow/modeling.py
+++ b/src/ds_workflow/modeling.py
@@ -1,0 +1,15 @@
+from sklearn.model_selection import cross_val_score
+from sklearn.preprocessing import StandardScaler
+from sklearn.linear_model import LogisticRegression
+from sklearn.ensemble import RandomForestClassifier
+
+
+def benchmark_models(X, y):
+    """Retorna as médias de acurácia de modelos simples."""
+    scaler = StandardScaler()
+    X_scaled = scaler.fit_transform(X)
+    lr = LogisticRegression(max_iter=1000)
+    rf = RandomForestClassifier(random_state=42)
+    lr_score = cross_val_score(lr, X_scaled, y, cv=5).mean()
+    rf_score = cross_val_score(rf, X, y, cv=5).mean()
+    return {"logistic_regression": lr_score, "random_forest": rf_score}

--- a/workflow_demo.ipynb
+++ b/workflow_demo.ipynb
@@ -1,0 +1,231 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Demonstra\u00e7\u00e3o de fluxo completo de Ci\u00eancia de Dados\n",
+    "Este notebook acompanha as etapas descritas no README: EDA, benchmarking de modelos, constru\u00e7\u00e3o de features, uso de uma feature store simples, integra\u00e7\u00e3o com MLflow e uma simula\u00e7\u00e3o de CI/CD com deploy can\u00e1rio."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 1. EDA"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "source": [
+    "import pandas as pd\n",
+    "import numpy as np\n",
+    "import matplotlib.pyplot as plt\n",
+    "import seaborn as sns\n",
+    "from scipy import stats\n",
+    "from sklearn.datasets import load_wine"
+   ],
+   "execution_count": null,
+   "outputs": []
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "source": [
+    "data = load_wine()\n",
+    "df = pd.DataFrame(data.data, columns=data.feature_names)\n",
+    "df['target'] = data.target\n",
+    "df.head()"
+   ],
+   "execution_count": null,
+   "outputs": []
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "source": [
+    "df.describe()"
+   ],
+   "execution_count": null,
+   "outputs": []
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "source": [
+    "sns.histplot(df['alcohol'], kde=True);\n",
+    "plt.show()"
+   ],
+   "execution_count": null,
+   "outputs": []
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "source": [
+    "sns.pairplot(df.sample(100), hue='target');"
+   ],
+   "execution_count": null,
+   "outputs": []
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "source": [
+    "corr = df.corr()\n",
+    "plt.figure(figsize=(10,8))\n",
+    "sns.heatmap(corr, cmap='coolwarm');"
+   ],
+   "execution_count": null,
+   "outputs": []
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Verificando a ader\u00eancia \u00e0 distribui\u00e7\u00e3o Normal de uma feature."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "source": [
+    "stat, p = stats.normaltest(df['alcohol'])\n",
+    "print('p-value', p)\n",
+    "if p < 0.05:\n",
+    "    print('Distribui\u00e7\u00e3o provavelmente n\u00e3o \u00e9 Normal')\n",
+    "else:\n",
+    "    print('Distribui\u00e7\u00e3o parece Normal')"
+   ],
+   "execution_count": null,
+   "outputs": []
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 2. Benchmark e escolha de modelo"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "source": [
+    "from sklearn.model_selection import cross_val_score, train_test_split\n",
+    "from sklearn.preprocessing import StandardScaler\n",
+    "from sklearn.linear_model import LogisticRegression\n",
+    "from sklearn.ensemble import RandomForestClassifier\n",
+    "X = df.drop('target', axis=1)\n",
+    "y = df['target']"
+   ],
+   "execution_count": null,
+   "outputs": []
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "source": [
+    "scaler = StandardScaler()\n",
+    "X_scaled = scaler.fit_transform(X)\n",
+    "lr = LogisticRegression(max_iter=1000)\n",
+    "rf = RandomForestClassifier(random_state=42)\n",
+    "lr_scores = cross_val_score(lr, X_scaled, y, cv=5)\n",
+    "rf_scores = cross_val_score(rf, X, y, cv=5)\n",
+    "print('LR mean accuracy:', lr_scores.mean())\n",
+    "print('RF mean accuracy:', rf_scores.mean())"
+   ],
+   "execution_count": null,
+   "outputs": []
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 3. Pipeline de features e Feature Store"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "source": [
+    "from sklearn.pipeline import Pipeline\n",
+    "from sklearn.feature_selection import SelectKBest, f_classif\n",
+    "feature_pipeline = Pipeline([\n",
+    "    ('scale', StandardScaler()),\n",
+    "    ('select', SelectKBest(score_func=f_classif, k=8))\n",
+    "])\n",
+    "X_features = feature_pipeline.fit_transform(X, y)\n",
+    "pd.DataFrame(X_features).to_csv('feature_store.csv', index=False)\n",
+    "X_features[:5]"
+   ],
+   "execution_count": null,
+   "outputs": []
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 4. Integra\u00e7\u00e3o com MLflow"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "source": [
+    "import mlflow\n",
+    "mlflow.set_experiment('wine_demo')\n",
+    "with mlflow.start_run():\n",
+    "    lr.fit(X_scaled, y)\n",
+    "    acc = lr.score(X_scaled, y)\n",
+    "    mlflow.log_metric('accuracy', acc)\n",
+    "    mlflow.sklearn.log_model(lr, 'model')\n",
+    "print('accuracy logged:', acc)"
+   ],
+   "execution_count": null,
+   "outputs": []
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 5. CI/CD e Deploy Can\u00e1rio (simulado)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "source": [
+    "import random\n",
+    "def simulate_canary(old_metric, new_metric, threshold=0.02):\n",
+    "    if new_metric + threshold < old_metric:\n",
+    "        print('Can\u00e1rio falhou, iniciando rollback...')\n",
+    "        return old_metric, False\n",
+    "    else:\n",
+    "        print('Novo modelo aprovado!')\n",
+    "        return new_metric, True\n",
+    "current_metric = lr_scores.mean()\n",
+    "candidate_metric = current_metric - 0.05  # simula piora\n",
+    "current_metric, ok = simulate_canary(current_metric, candidate_metric)\n",
+    "if not ok:\n",
+    "    candidate_metric = current_metric + 0.03  # nova vers\u00e3o melhor\n",
+    "    current_metric, _ = simulate_canary(current_metric, candidate_metric)"
+   ],
+   "execution_count": null,
+   "outputs": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python",
+   "version": "3.11"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}


### PR DESCRIPTION
## Summary
- modularize the demo workflow into `src/ds_workflow` package
- add orchestrator script that ties EDA, modeling, feature pipeline, MLflow logging and canary deployment
- document the new module layout in the README

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6855a9a6efb0832391264da36df39bf9